### PR TITLE
fix(embed): fix server embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,13 @@ Plotly Dash integration for Frappe web framework
 
 ### Usage
 
-You have to edit frappe apps in `frappe/frappe/website/render.py`
+### For development setup
 
-add these line on top of render function
-
-```python
-from dash_integration.app import dash_render
-
-@dash_render
-def render(path=None, http_status_code=None):
-```
+    bench execute dash_integration.app.serve
 
 ### Description
+
+For iFrame resizing we use ResizeObserver, it compatible for most of the browser but not all. Check compatibility at caniuse.
 
 [CoreUi bootstrap admin template](https://github.com/coreui/coreui-free-bootstrap-admin-template/) is use to templating dash page. 
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,27 @@ Plotly Dash integration for Frappe web framework
 
 ### Usage
 
-#### For development setup
-    bench execute dash_integration.app.serve
+You have to edit frappe apps in `frappe/frappe/app.py`
+
+import function at the top of the file
+
+`from dash_integration.app import build_ajax, build_page`
+
+in application function `def application(request):` add these line
+
+    if frappe.local.form_dict.cmd:
+        response = frappe.handler.handle()
+
+    elif frappe.request.path.startswith("/dash/_dash"):
+        response = build_ajax(request)
+
+    elif frappe.request.path.startswith("/dash/"):
+        response = build_page(request)
+
+    elif frappe.request.path.startswith("/api/"):
+        response = frappe.api.handle()
 
 ### Description
-
-For iFrame resizing we use `ResizeObserver`, it compatible for most of the browser but not all. Check compatibility at [caniuse](https://caniuse.com/#feat=resizeobserver).
 
 [CoreUi bootstrap admin template](https://github.com/coreui/coreui-free-bootstrap-admin-template/) is use to templating dash page. 
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,16 @@ Plotly Dash integration for Frappe web framework
 
 ### Usage
 
-You have to edit frappe apps in `frappe/frappe/app.py`
+You have to edit frappe apps in `frappe/frappe/website/render.py`
 
-import function at the top of the file
+add these line on top of render function
 
-`from dash_integration.app import build_ajax, build_page`
+```python
+from dash_integration.app import dash_render
 
-in application function `def application(request):` add these line
-
-    if frappe.local.form_dict.cmd:
-        response = frappe.handler.handle()
-
-    elif frappe.request.path.startswith("/dash/_dash"):
-        response = build_ajax(request)
-
-    elif frappe.request.path.startswith("/dash/"):
-        response = build_page(request)
-
-    elif frappe.request.path.startswith("/api/"):
-        response = frappe.api.handle()
+@dash_render
+def render(path=None, http_status_code=None):
+```
 
 ### Description
 

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -57,6 +57,7 @@ dash_app.layout = html.Div([
 # set frappe
 dash_app.fp = frappe
 
+
 # router for dash app
 @dash_app.callback(
     dash.dependencies.Output('page-content', 'children'),

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -61,11 +61,10 @@ dash_app.fp = frappe
 @dash_app.callback(
     dash.dependencies.Output('page-content', 'children'),
     [
-        dash.dependencies.Input('url', 'pathname'),
         dash.dependencies.Input('url', 'href'),
     ]
 )
-def display_page(pathname, href):
+def display_page(href):
     from dash_integration.dashboard import simple_dash
     from dash_integration.dashboard import simple_dash2
 
@@ -108,14 +107,14 @@ def display_page(pathname, href):
                 dashboard_name=dashboard,
                 username=user,
             ):
-                return 'You are not permitted to access this page.'
-            else:
                 if dashboard == 'Testing 1':
                     return simple_dash.get_layout()
-                elif pathname == 'Testing 2':
+                elif dashboard == 'Testing 2':
                     return simple_dash2.layout
                 else:
                     return '404'
+            else:
+                return 'You are not permitted to access this page.'
         return 'You are not permitted to access this page.'
     else:
         return ''

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -1,83 +1,125 @@
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
-import json
-import frappe
+from __future__ import unicode_literals
 
-from flask import Flask
-from werkzeug.wrappers import Response
+from dash_integration.dash_app import build_ajax, build_page
+from frappe.app import *
 
 
-# load dash application
-server = Flask(__name__)
-dash_app = dash.Dash(
-    __name__,
-    server=server,
-    url_base_pathname='/dash/'
-)
-
-# config
-dash_app.config.suppress_callback_exceptions = True
-
-# dash layout
-dash_app.layout = html.Div([
-    dcc.Location(id='url', refresh=False),
-    html.H1('HELLO FROM DASH EMBED'),
-    html.Div(id='page-content'),
-])
+local_manager = LocalManager([frappe.local])
 
 
-def dash_dispatcher(request):
-    params = {
-        'method': request.method,
-        'content_type': request.content_type
+@Request.application
+def application(request):
+    response = None
+
+    try:
+        rollback = True
+
+        init_request(request)
+
+        frappe.recorder.record()
+
+        if frappe.local.form_dict.cmd:
+            response = frappe.handler.handle()
+
+        # dash router
+        # ####################################################
+        elif frappe.request.path.startswith("/dash/_dash"):
+            response = build_ajax(request)
+        elif frappe.request.path.startswith("/dash/"):
+            response = build_page(request)
+        # ####################################################
+
+        elif frappe.request.path.startswith("/api/"):
+            response = frappe.api.handle()
+
+        elif frappe.request.path.startswith('/backups'):
+            response = frappe.utils.response.download_backup(request.path)
+
+        elif frappe.request.path.startswith('/private/files/'):
+            response = frappe.utils.response.download_private_file(request.path)
+
+        elif frappe.local.request.method in ('GET', 'HEAD', 'POST'):
+            response = frappe.website.render.render()
+
+        else:
+            raise NotFound
+
+    except HTTPException as e:
+        return e
+
+    except frappe.SessionStopped as e:
+        response = frappe.utils.response.handle_session_stopped()
+
+    except Exception as e:
+        # dash router
+        # ####################################################
+        if frappe.request.path.startswith("/dash/_dash"):
+            response = build_ajax(request)
+        # ####################################################
+        else:
+            response = handle_exception(e)
+
+    else:
+        rollback = after_request(rollback)
+
+    finally:
+        if frappe.local.request.method in ("POST", "PUT") and frappe.db and rollback:
+            frappe.db.rollback()
+
+        # set cookies
+        if response and hasattr(frappe.local, 'cookie_manager'):
+            frappe.local.cookie_manager.flush_cookies(response=response)
+
+        frappe.recorder.dump()
+
+        frappe.destroy()
+
+    return response
+
+
+application = local_manager.make_middleware(application)
+
+
+def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=None, sites_path='.'):
+    global application, _site, _sites_path
+    _site = site
+    _sites_path = sites_path
+
+    from werkzeug.serving import run_simple
+
+    if profile:
+        application = ProfilerMiddleware(
+            application,
+            sort_by=('cumtime', 'calls'),
+        )
+
+    if not os.environ.get('NO_STATICS'):
+        application = SharedDataMiddleware(
+            application,
+            {
+                str('/assets'): str(os.path.join(sites_path, 'assets')),
+            },
+        )
+
+        application = StaticDataMiddleware(
+            application,
+            {
+                str('/files'): str(os.path.abspath(sites_path))
+            },
+        )
+
+    application.debug = True
+    application.config = {
+        'SERVER_NAME': 'localhost:8000'
     }
 
-    # todo: check test_request_context function
-    with server.test_request_context(request.path, **params):
-        server.preprocess_request()
-        try:
-            response = server.full_dispatch_request()
-        except Exception as e:
-            response = server.make_response(server.handle_exception(e))
-        return response.get_data()
+    in_test_env = os.environ.get('CI')
+    if in_test_env:
+        log = logging.getLogger('werkzeug')
+        log.setLevel(logging.ERROR)
 
-
-def build_ajax(request):
-    response = Response()
-
-    data = dash_dispatcher(request)
-    if isinstance(data, dict):
-        data = json.dumps(data)
-    response.data = data
-
-    response.status_code = 200
-    response.mimetype = 'application/json'
-    response.charset = 'utf-8'
-
-    return response
-
-
-def build_page(request):
-    response = Response()
-
-    data = dash_dispatcher(request)
-    response.data = data
-
-    response.status_code = 200
-    response.mimetype = 'text/html'
-    response.charset = 'utf-8'
-
-    return response
-
-
-def dash_render(frappe_render):
-    def render(*args, **kwargs):
-        if frappe.request.path.startswith("/dash/_dash"):
-            return build_ajax(frappe.request)
-        elif frappe.request.path.startswith("/dash/"):
-            return build_page(frappe.request)
-        else:
-            return frappe_render(*args, **kwargs)
-
-    return render
+    run_simple('0.0.0.0', int(port), application,
+        use_reloader=False if in_test_env else not no_reload,
+        use_debugger=not in_test_env,
+        use_evalex=not in_test_env,
+        threaded=not no_threading)

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -1,163 +1,70 @@
 import dash
 import dash_core_components as dcc
 import dash_html_components as html
-import os
-import logging
-import frappe
-import flask
-import requests
-import urllib
+import json
 
-from werkzeug.wsgi import DispatcherMiddleware
-from werkzeug.contrib.profiler import ProfilerMiddleware
-from werkzeug.wsgi import SharedDataMiddleware
-from werkzeug.serving import run_simple
-
-from frappe.app import application
-from frappe.middlewares import StaticDataMiddleware
-from dash_integration.dash_integration.page.dash import check_permitted
-
-
-def dash_render_template(template_name):
-    # default render template by frappe
-    template = frappe.render_template(template_name, context={})
-
-    # replacing custom context
-    template = template.replace('[%', '{%')
-    template = template.replace('%]', '%}')
-
-    return template
+from flask import Flask
+from werkzeug.wrappers import Response
 
 
 # load dash application
-flask_server = flask.Flask(__name__)
+server = Flask(__name__)
 dash_app = dash.Dash(
     __name__,
-    server=flask_server,
+    server=server,
+    url_base_pathname='/dash/'
 )
 
 # config
 dash_app.config.suppress_callback_exceptions = True
-dash_app.config.update({
-    'requests_pathname_prefix': '/dash/'
-})
-
-# Override the underlying HTML template
-html_layout = dash_render_template(
-    template_name='templates/dashboard.html',
-)
-dash_app.index_string = html_layout
 
 # dash layout
 dash_app.layout = html.Div([
     dcc.Location(id='url', refresh=False),
+    html.H1('HELLO FROM DASH EMBED'),
     html.Div(id='page-content'),
 ])
 
 
-# router for dash app
-@dash_app.callback(
-    dash.dependencies.Output('page-content', 'children'),
-    [
-        dash.dependencies.Input('url', 'href'),
-    ]
-)
-def display_page(href):
-    from dash_integration.dashboard import simple_dash
-    from dash_integration.dashboard import simple_dash2
-
-    if href:
-        # extract information from url
-        parsed_uri = urllib.parse.urlparse(href)
-        url_param = urllib.parse.parse_qs(parsed_uri.query)
-        sid = url_param.get('sid', '')
-        site_name = url_param.get('site_name', '')
-        if site_name:
-            site_name = site_name[0]
-        dashboard = url_param.get('dash', '')
-        if dashboard:
-            dashboard = dashboard[0]
-        domain = '{uri.scheme}://{uri.netloc}'.format(uri=parsed_uri)
-
-        # prepare for api
-        get_user_info_api = '/api/method/frappe.realtime.get_user_info'
-        get_user_info_api_url = '{}{}'.format(domain, get_user_info_api)
-        user_param = {'sid': sid}
-
-        # call api
-        response = requests.get(
-            get_user_info_api_url,
-            params=user_param
-        )
-        if response.status_code == 200:
-            user = response.json()['message'].get('user', '')
-
-        # test frappe connection
-        frappe_connected = False
-        if site_name:
-            frappe.connect(site_name)
-            frappe_connected = True
-
-        # display page
-        if frappe_connected:
-            # check user permission
-            if check_permitted(
-                dashboard_name=dashboard,
-                username=user,
-            ):
-                if dashboard == 'Testing 1':
-                    return simple_dash.get_layout()
-                elif dashboard == 'Testing 2':
-                    return simple_dash2.layout
-                else:
-                    return '404'
-            else:
-                return 'You are not permitted to access this page.'
-        return 'You are not permitted to access this page.'
-    else:
-        return ''
-
-
-# attach dash to frappe
-application = DispatcherMiddleware(application, {
-    '/dash': dash_app.server,
-})
-
-
-# custom "serve" command to run frappe with dash
-# modified from frappe.app
-def serve(application=application, port=8000, profile=False, no_reload=False, no_threading=False, sites_path='.'):
-    if profile:
-        application = ProfilerMiddleware(
-            application,
-            sort_by=('cumtime', 'calls')
-        )
-
-    if not os.environ.get('NO_STATICS'):
-        application = SharedDataMiddleware(application, {
-            str('/assets'): str(os.path.join(sites_path, 'assets'))
-        })
-
-        application = StaticDataMiddleware(application, {
-            str('/files'): str(os.path.abspath(sites_path))
-        })
-
-    application.debug = True
-    application.config = {
-        'SERVER_NAME': 'localhost:8000'
+def dash_dispatcher(request):
+    params = {
+        'method': request.method,
+        'content_type': request.content_type
     }
 
-    in_test_env = os.environ.get('CI')
-    if in_test_env:
-        log = logging.getLogger('werkzeug')
-        log.setLevel(logging.ERROR)
+    # todo: check test_request_context function
+    with server.test_request_context(request.path, **params):
+        server.preprocess_request()
+        try:
+            response = server.full_dispatch_request()
+        except Exception as e:
+            response = server.make_response(server.handle_exception(e))
+        return response.get_data()
 
-    run_simple(
-        '0.0.0.0',
-        int(port),
-        application,
-        use_reloader=False if in_test_env else not no_reload,
-        use_debugger=not in_test_env,
-        use_evalex=not in_test_env,
-        threaded=not no_threading
-    )
+
+def build_ajax(request):
+    response = Response()
+
+    data = dash_dispatcher(request)
+    if isinstance(data, dict):
+        data = json.dumps(data)
+    response.data = data
+
+    response.status_code = 200
+    response.mimetype = 'application/json'
+    response.charset = 'utf-8'
+
+    return response
+
+
+def build_page(request):
+    response = Response()
+
+    data = dash_dispatcher(request)
+    response.data = data
+
+    response.status_code = 200
+    response.mimetype = 'text/html'
+    response.charset = 'utf-8'
+
+    return response

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -2,6 +2,7 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 import json
+import frappe
 
 from flask import Flask
 from werkzeug.wrappers import Response
@@ -68,3 +69,15 @@ def build_page(request):
     response.charset = 'utf-8'
 
     return response
+
+
+def dash_render(frappe_render):
+    def render(*args, **kwargs):
+        if frappe.request.path.startswith("/dash/_dash"):
+            return build_ajax(frappe.request)
+        elif frappe.request.path.startswith("/dash/"):
+            return build_page(frappe.request)
+        else:
+            return frappe_render(*args, **kwargs)
+
+    return render

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -54,9 +54,6 @@ dash_app.layout = html.Div([
     html.Div(id='page-content'),
 ])
 
-# set frappe
-dash_app.fp = frappe
-
 
 # router for dash app
 @dash_app.callback(
@@ -98,7 +95,7 @@ def display_page(href):
         # test frappe connection
         frappe_connected = False
         if site_name:
-            dash_app.fp.connect(site_name)
+            frappe.connect(site_name)
             frappe_connected = True
 
         # display page

--- a/dash_integration/app.py
+++ b/dash_integration/app.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from dash_integration.dash_app import build_ajax, build_page
+from dash_integration.dash_application import build_ajax, build_page
 from frappe.app import *
 
 

--- a/dash_integration/auth.py
+++ b/dash_integration/auth.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def has_desk_permission():
+    desk_permission = not (
+        frappe.session.user == 'Guest' or
+        frappe.db.get_value('User', frappe.session.user, 'user_type') == 'Website User'
+    )
+
+    return desk_permission

--- a/dash_integration/auth.py
+++ b/dash_integration/auth.py
@@ -11,3 +11,29 @@ def has_desk_permission():
     )
 
     return desk_permission
+
+
+def has_dashboard_permission(dashboard):
+    user = frappe.session.user
+
+    # get allow role for dashboard
+    allowed_roles_dict = frappe.get_all(
+        'Has Role',
+        fields=['role'],
+        filters={
+            'parenttype': 'Dash Dashboard',
+            'parent': dashboard,
+        }
+    )
+
+    # convert list of role dict to role list
+    allow_roles = []
+    for roles_dict in allowed_roles_dict:
+        role = roles_dict.get('role')
+        if role:
+            allow_roles.append(role)
+
+    # get user roles
+    user_roles = frappe.permissions.get_roles(user)
+
+    return frappe.utils.has_common(allow_roles, user_roles)

--- a/dash_integration/auth.py
+++ b/dash_integration/auth.py
@@ -2,9 +2,12 @@ import frappe
 
 
 def has_desk_permission():
+    user = frappe.session.user
+    user_type = frappe.db.get_value('User', user, 'user_type')
+
     desk_permission = not (
-        frappe.session.user == 'Guest' or
-        frappe.db.get_value('User', frappe.session.user, 'user_type') == 'Website User'
+        (user == 'Guest') or
+        (user_type == 'Website User')
     )
 
     return desk_permission

--- a/dash_integration/dash_app.py
+++ b/dash_integration/dash_app.py
@@ -1,0 +1,71 @@
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+import json
+import frappe
+
+from flask import Flask
+from werkzeug.wrappers import Response
+
+
+# load dash application
+server = Flask(__name__)
+dash_app = dash.Dash(
+    __name__,
+    server=server,
+    url_base_pathname='/dash/'
+)
+
+# config
+dash_app.config.suppress_callback_exceptions = True
+
+# dash layout
+dash_app.layout = html.Div([
+    dcc.Location(id='url', refresh=False),
+    html.H1('HELLO FROM DASH EMBED'),
+    html.Div(id='page-content'),
+])
+
+
+def dash_dispatcher(request):
+    params = {
+        'method': request.method,
+        'content_type': request.content_type
+    }
+
+    # todo: check test_request_context function
+    with server.test_request_context(request.path, **params):
+        server.preprocess_request()
+        try:
+            response = server.full_dispatch_request()
+        except Exception as e:
+            response = server.make_response(server.handle_exception(e))
+        return response.get_data()
+
+
+def build_ajax(request):
+    response = Response()
+
+    data = dash_dispatcher(request)
+    if isinstance(data, dict):
+        data = json.dumps(data)
+    response.data = data
+
+    response.status_code = 200
+    response.mimetype = 'application/json'
+    response.charset = 'utf-8'
+
+    return response
+
+
+def build_page(request):
+    response = Response()
+
+    data = dash_dispatcher(request)
+    response.data = data
+
+    response.status_code = 200
+    response.mimetype = 'text/html'
+    response.charset = 'utf-8'
+
+    return response

--- a/dash_integration/dash_application.py
+++ b/dash_integration/dash_application.py
@@ -26,14 +26,10 @@ dash_app.layout = html.Div([
     html.Div(id='my-div')
 ])
 
-
-# router
-@dash_app.callback(
-    Output(component_id='my-div', component_property='children'),
-    [Input(component_id='my-id', component_property='value')]
-)
-def update_output_div(input_value):
-    return 'You\'ve entered "{}"'.format(input_value)
+# registered callback
+with server.app_context():
+    from dash_integration.router import callback
+    callback()
 
 
 def dash_dispatcher(request):

--- a/dash_integration/dash_application.py
+++ b/dash_integration/dash_application.py
@@ -1,12 +1,8 @@
 import dash
-import dash_core_components as dcc
-import dash_html_components as html
 import json
-import frappe
 
 from flask import Flask
 from werkzeug.wrappers import Response
-from dash.dependencies import Input, Output
 
 
 # load dash application
@@ -20,34 +16,15 @@ dash_app = dash.Dash(
 # config
 dash_app.config.suppress_callback_exceptions = True
 
-# dash layout
-dash_app.layout = html.Div([
-    dcc.Location(id='url', refresh=False),
-    html.Div(id='page-content'),
-])
-
-
-def dash_render_template(template_name):
-    # default render template by frappe
-    template = frappe.render_template(template_name, context={})
-
-    # replacing custom context
-    template = template.replace('[%', '{%')
-    template = template.replace('%]', '%}')
-
-    return template
-
-
-# Override the underlying HTML template
-html_layout = dash_render_template(
-    template_name='templates/dashboard.html',
-)
-dash_app.index_string = html_layout
-
-# registered callback
+# registered dash config
 with server.app_context():
+    # router
     from dash_integration.router import callback
     callback()
+
+    # layout
+    from dash_integration.layout import config_layout
+    config_layout(dash_app)
 
 
 def dash_dispatcher(request):

--- a/dash_integration/dash_application.py
+++ b/dash_integration/dash_application.py
@@ -22,8 +22,8 @@ dash_app.config.suppress_callback_exceptions = True
 
 # dash layout
 dash_app.layout = html.Div([
-    dcc.Input(id='my-id', value='initial value', type='text'),
-    html.Div(id='my-div')
+    dcc.Location(id='url', refresh=False),
+    html.Div(id='page-content'),
 ])
 
 # registered callback

--- a/dash_integration/dash_application.py
+++ b/dash_integration/dash_application.py
@@ -6,6 +6,7 @@ import frappe
 
 from flask import Flask
 from werkzeug.wrappers import Response
+from dash.dependencies import Input, Output
 
 
 # load dash application
@@ -21,14 +22,23 @@ dash_app.config.suppress_callback_exceptions = True
 
 # dash layout
 dash_app.layout = html.Div([
-    dcc.Location(id='url', refresh=False),
-    html.H1('HELLO FROM DASH EMBED'),
-    html.Div(id='page-content'),
+    dcc.Input(id='my-id', value='initial value', type='text'),
+    html.Div(id='my-div')
 ])
+
+
+# router
+@dash_app.callback(
+    Output(component_id='my-div', component_property='children'),
+    [Input(component_id='my-id', component_property='value')]
+)
+def update_output_div(input_value):
+    return 'You\'ve entered "{}"'.format(input_value)
 
 
 def dash_dispatcher(request):
     params = {
+        'data': request.data,
         'method': request.method,
         'content_type': request.content_type
     }

--- a/dash_integration/dash_application.py
+++ b/dash_integration/dash_application.py
@@ -26,6 +26,24 @@ dash_app.layout = html.Div([
     html.Div(id='page-content'),
 ])
 
+
+def dash_render_template(template_name):
+    # default render template by frappe
+    template = frappe.render_template(template_name, context={})
+
+    # replacing custom context
+    template = template.replace('[%', '{%')
+    template = template.replace('%]', '%}')
+
+    return template
+
+
+# Override the underlying HTML template
+html_layout = dash_render_template(
+    template_name='templates/dashboard.html',
+)
+dash_app.index_string = html_layout
+
 # registered callback
 with server.app_context():
     from dash_integration.router import callback

--- a/dash_integration/dash_integration/page/dash/dash.js
+++ b/dash_integration/dash_integration/page/dash/dash.js
@@ -94,8 +94,7 @@ function createSelectionField(wrapper) {
 */
 function changeIframeUrl(dashboardName) {
 	const siteOrigin = window.location.origin;
-
-	const iframeUrl = `${siteOrigin}/dash?sid=${dash.sid}&site_name=${dash.siteName}&dash=${dashboardName}`;
+	const iframeUrl = `${siteOrigin}/dash/dashboard?sid=${dash.sid}&dash=${dashboardName}`;
 	$('#dash-iframe').attr('src', iframeUrl);
 }
 

--- a/dash_integration/dash_integration/page/dash/dash.js
+++ b/dash_integration/dash_integration/page/dash/dash.js
@@ -1,8 +1,6 @@
-const dash = {};
+/* eslint require-jsdoc: 0 */
 
 frappe.pages['dash'].on_page_load = (wrapper) => {
-	dash.wrapper = wrapper;
-
 	// init page
 	const page = frappe.ui.make_app_page({
 		'parent': wrapper,
@@ -10,96 +8,92 @@ frappe.pages['dash'].on_page_load = (wrapper) => {
 		'single_column': true,
 	});
 
-	attachIframe(page);
-	createSelectionField(wrapper);
+	new Dash(page, wrapper);
 };
 
 
-/** Attach iframe to page
- * @param {object} page
-*/
-function attachIframe(page) {
-	// attach iframe
-	const iframeHtml = `
-		<iframe
-		id="dash-iframe"
-		style="
-			border: none;
-			width: 100%;
-		">
-		</iframe>
-	`;
-	$(page.main).append(iframeHtml);
-
-	/** Resize iframe function.
-	 * @param {object} event - A string param
-	 */
-	function resizeIframe(event) {
-		const dashIframe = document.getElementById('dash-iframe');
-		const frameHeight = event.data.frameHeight;
-		dashIframe.style.height = `${frameHeight + 30}px`;
+class Dash {
+	constructor(page, wrapper) {
+		this.wrapper = wrapper;
+		this.page = page;
+		this.siteOrigin = window.location.origin;
+		this.pageMain = $(page.main);
+		this.pageAction = (
+			$(this.wrapper)
+				.find('div.page-head div.page-actions')
+		);
+		this.pageTitle = $(this.wrapper).find('div.title-text');
+		this.iframeHtml = `
+			<iframe
+			id="dash-iframe"
+			style="
+				border: none;
+				width: 100%;
+			">
+			</iframe>
+		`;
+		this.init();
 	}
-	// attach resizer
-	window.addEventListener('message', resizeIframe, false);
-}
 
+	init() {
+		// attatch iframe
+		this.$dashIframe = $(this.iframeHtml).appendTo(this.pageMain);
+		// attatch iframe resizer
+		this.resizer();
+		// attatch dashboard selector
+		this.createSelectionField();
+	}
 
-/** Create customer dashboard selection field
- * @param {object} wrapper
- */
-function createSelectionField(wrapper) {
-	const $pageAction = (
-		$(wrapper)
-			.find('div.page-head div.page-actions')
-	);
-	// remove change page-actions class
-	$pageAction.removeClass('page-actions');
+	resizer() {
+		window.addEventListener('message', resize, false);
+		function resize(event) {
+			const dashIframe = document.getElementById('dash-iframe');
+			const frameHeight = event.data.frameHeight;
+			dashIframe.style.height = `${frameHeight + 30}px`;
+		}
+	}
 
-	// create dashboard selection field
-	const selDashboard = frappe.ui.form.make_control({
-		'parent': $pageAction,
-		'df': {
-			'fieldname': 'Dashboard',
-			'fieldtype': 'Link',
-			'options': 'Dash Dashboard',
-			'onchange': () => {
-				const dashboardName = selDashboard.get_value();
-				if (dashboardName) {
-					changeIframeUrl(dashboardName);
-					changeTitle(dashboardName);
-					// clear input
-					selDashboard.set_input('');
-				}
+	createSelectionField() {
+		// create dashboard selection field
+		this.selectionField = frappe.ui.form.make_control({
+			'parent': this.pageAction,
+			'df': {
+				'fieldname': 'Dashboard',
+				'fieldtype': 'Link',
+				'options': 'Dash Dashboard',
+				'onchange': () => {
+					const dashboardName = this.selectionField.get_value();
+					if (dashboardName) {
+						this.dashboardName = dashboardName;
+						this.changeIframeUrl();
+						this.changeTitle(dashboardName);
+						// clear input
+						this.selectionField.set_input('');
+					}
+				},
+				'get_query': () => {
+					return {
+						'filters': {
+							'is_active': 1,
+						},
+					};
+				},
+				'placeholder': 'Select Dashboard',
 			},
-			'get_query': () => {
-				return {
-					'filters': {
-						'is_active': 1,
-					},
-				};
-			},
-			'placeholder': 'Select Dashboard',
-		},
-		'render_input': true,
-	});
-	selDashboard.$wrapper.css('text-align', 'left');
-}
+			'render_input': true,
+		});
 
+		// change css
+		this.pageAction.removeClass('page-actions');
+		this.selectionField.$wrapper.css('text-align', 'left');
+	}
 
-/** Change Iframe url
- * @param {str} dashboardName
-*/
-function changeIframeUrl(dashboardName) {
-	const siteOrigin = window.location.origin;
-	const iframeUrl = `${siteOrigin}/dash/dashboard?dash=${dashboardName}`;
-	$('#dash-iframe').attr('src', iframeUrl);
-}
+	changeIframeUrl() {
+		this.iframeUrl = `${this.siteOrigin}/dash/dashboard?dash=${this.dashboardName}`;
+		this.$dashIframe.attr('src', this.iframeUrl);
+	}
 
-
-/** Change page title
- * @param {str} title
-*/
-function changeTitle(title) {
-	const pageTitle = $(dash.wrapper).find('div.title-text');
-	pageTitle.text(`${title} Dashboard`);
+	changeTitle() {
+		this.pageTitle.text(`${this.dashboardName} Dashboard`);
+	}
 }

--- a/dash_integration/dash_integration/page/dash/dash.js
+++ b/dash_integration/dash_integration/page/dash/dash.js
@@ -2,7 +2,6 @@ const dash = {};
 
 frappe.pages['dash'].on_page_load = (wrapper) => {
 	const cookie = frappe.get_cookies();
-	dash.sid = cookie.sid;
 	dash.siteName = frappe.boot.sitename;
 	dash.wrapper = wrapper;
 
@@ -94,7 +93,7 @@ function createSelectionField(wrapper) {
 */
 function changeIframeUrl(dashboardName) {
 	const siteOrigin = window.location.origin;
-	const iframeUrl = `${siteOrigin}/dash/dashboard?sid=${dash.sid}&dash=${dashboardName}`;
+	const iframeUrl = `${siteOrigin}/dash/dashboard?dash=${dashboardName}`;
 	$('#dash-iframe').attr('src', iframeUrl);
 }
 

--- a/dash_integration/dash_integration/page/dash/dash.js
+++ b/dash_integration/dash_integration/page/dash/dash.js
@@ -1,8 +1,6 @@
 const dash = {};
 
 frappe.pages['dash'].on_page_load = (wrapper) => {
-	const cookie = frappe.get_cookies();
-	dash.siteName = frappe.boot.sitename;
 	dash.wrapper = wrapper;
 
 	// init page

--- a/dash_integration/dashboard/simple_dash.py
+++ b/dash_integration/dashboard/simple_dash.py
@@ -4,7 +4,7 @@ import frappe
 
 from dash.dependencies import Input, Output
 
-from dash_integration.app import dash_app
+from dash_integration.dash_application import dash_app
 
 
 def get_layout():

--- a/dash_integration/dashboard/simple_dash.py
+++ b/dash_integration/dashboard/simple_dash.py
@@ -1,15 +1,15 @@
 import dash_core_components as dcc
 import dash_html_components as html
+import frappe
 
 from dash.dependencies import Input, Output
 
 from dash_integration.app import dash_app
 
 
-
 def get_layout():
     print('=====================')
-    print(dash_app.fp.db.get_value('User', 'Administrator', 'user_type'))
+    print(frappe.db.get_value('User', 'Administrator', 'user_type'))
     print('=====================')
 
     layout = [

--- a/dash_integration/dashboard/simple_dash2.py
+++ b/dash_integration/dashboard/simple_dash2.py
@@ -1,5 +1,6 @@
 import dash_core_components as dcc
 import dash_html_components as html
+import frappe
 
 from dash.dependencies import Input, Output
 
@@ -14,8 +15,8 @@ layout = [
                     'Testing Dashboard'
                 ], className='card-header'),
                 html.Div([
-                    dcc.Input(id='my-id', value='initial value', type='text'),
-                    html.Div(id='my-div')
+                    dcc.Input(id='aaa', value='initial value', type='text'),
+                    html.Div(id='bbb')
                 ], className='card-body'),
             ], className='card')
         ], className='col-md-12')
@@ -28,4 +29,7 @@ layout = [
     [Input(component_id='aaa', component_property='value')]
 )
 def update_output_div(input_value):
+    print('=====================')
+    print('callback', frappe.db.get_value('User', 'Administrator', 'user_type'))
+    print('=====================')
     return 'You\'ve entered "{}"'.format(input_value)

--- a/dash_integration/dashboard/simple_dash2.py
+++ b/dash_integration/dashboard/simple_dash2.py
@@ -4,7 +4,7 @@ import frappe
 
 from dash.dependencies import Input, Output
 
-from dash_integration.app import dash_app
+from dash_integration.dash_application import dash_app
 
 
 layout = [

--- a/dash_integration/layout.py
+++ b/dash_integration/layout.py
@@ -1,0 +1,29 @@
+import dash_core_components as dcc
+import dash_html_components as html
+
+from frappe import render_template
+
+
+def config_layout(dash_app):
+    # dash layout
+    dash_app.layout = html.Div([
+        dcc.Location(id='url', refresh=False),
+        html.Div(id='page-content'),
+    ])
+
+    # Override the underlying HTML template
+    html_layout = dash_render_template(
+        template_name='templates/dashboard.html',
+    )
+    dash_app.index_string = html_layout
+
+
+def dash_render_template(template_name):
+    # default render template by frappe
+    template = render_template(template_name, context={})
+
+    # replacing custom context
+    template = template.replace('[%', '{%')
+    template = template.replace('%]', '%}')
+
+    return template

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -9,8 +9,8 @@ def callback():
     @dash_app.callback(
         Output('page-content', 'children'),
         [
-            dash.dependencies.Input('url', 'pathname'),
-            dash.dependencies.Input('url', 'href'),
+            Input('url', 'pathname'),
+            Input('url', 'href'),
         ],
     )
     def display_page(pathname, href):

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -10,14 +10,10 @@ def callback():
     @dash_app.callback(
         Output('page-content', 'children'),
         [
-            Input('url', 'pathname'),
             Input('url', 'href'),
         ],
     )
-    def display_page(pathname, href):
-        from dash_integration.dashboard import simple_dash
-        from dash_integration.dashboard import simple_dash2
-
+    def display_page(href):
         if href:
             # extract information from url
             parsed_uri = urllib.parse.urlparse(href)
@@ -26,13 +22,20 @@ def callback():
 
             if has_desk_permission():
                 if has_dashboard_permission(dashboard):
-                    if dashboard == 'Testing 1':
-                        return simple_dash.get_layout()
-                    elif dashboard == 'Testing 2':
-                        return simple_dash2.layout
-                    else:
-                        return '404'
+                    return dash_route(dashboard)
                 else:
                     return 'You are not permitted to access this dashboard'
             else:
                 return 'You are not permitted to access this page'
+
+
+def dash_route(dashboard):
+    from dash_integration.dashboard import simple_dash
+    from dash_integration.dashboard import simple_dash2
+
+    if dashboard == 'Testing 1':
+        return simple_dash.get_layout()
+    elif dashboard == 'Testing 2':
+        return simple_dash2.layout
+    else:
+        return '404'

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -21,11 +21,11 @@ def callback():
             # extract information from url
             parsed_uri = urllib.parse.urlparse(href)
             url_param = urllib.parse.parse_qs(parsed_uri.query)
-            dashboard = url_param.get('dashboard', '')[0]
+            dashboard = url_param.get('dash', '')[0]
 
-            if dashboard == 'Test1':
+            if dashboard == 'Testing 1':
                 return simple_dash.get_layout()
-            elif dashboard == 'Test2':
+            elif dashboard == 'Testing 2':
                 return simple_dash2.layout
             else:
                 return '404'

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -1,0 +1,11 @@
+from dash_integration.dash_application import dash_app
+from dash.dependencies import Input, Output
+
+
+def callback():
+    @dash_app.callback(
+        Output(component_id='my-div', component_property='children'),
+        [Input(component_id='my-id', component_property='value')]
+    )
+    def update_output_div(input_value):
+        return 'You\'ve entered "{}"'.format(input_value)

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -1,7 +1,7 @@
-import dash
 import urllib
 
 from dash_integration.dash_application import dash_app
+from dash_integration.auth import has_desk_permission
 from dash.dependencies import Input, Output
 
 
@@ -23,9 +23,12 @@ def callback():
             url_param = urllib.parse.parse_qs(parsed_uri.query)
             dashboard = url_param.get('dash', '')[0]
 
-            if dashboard == 'Testing 1':
-                return simple_dash.get_layout()
-            elif dashboard == 'Testing 2':
-                return simple_dash2.layout
+            if has_desk_permission():
+                if dashboard == 'Testing 1':
+                    return simple_dash.get_layout()
+                elif dashboard == 'Testing 2':
+                    return simple_dash2.layout
+                else:
+                    return '404'
             else:
-                return '404'
+                return 'You are not permitted to access this page'

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -2,6 +2,7 @@ import urllib
 
 from dash_integration.dash_application import dash_app
 from dash_integration.auth import has_desk_permission
+from dash_integration.auth import has_dashboard_permission
 from dash.dependencies import Input, Output
 
 
@@ -24,11 +25,14 @@ def callback():
             dashboard = url_param.get('dash', '')[0]
 
             if has_desk_permission():
-                if dashboard == 'Testing 1':
-                    return simple_dash.get_layout()
-                elif dashboard == 'Testing 2':
-                    return simple_dash2.layout
+                if has_dashboard_permission(dashboard):
+                    if dashboard == 'Testing 1':
+                        return simple_dash.get_layout()
+                    elif dashboard == 'Testing 2':
+                        return simple_dash2.layout
+                    else:
+                        return '404'
                 else:
-                    return '404'
+                    return 'You are not permitted to access this dashboard'
             else:
                 return 'You are not permitted to access this page'

--- a/dash_integration/router.py
+++ b/dash_integration/router.py
@@ -1,11 +1,31 @@
+import dash
+import urllib
+
 from dash_integration.dash_application import dash_app
 from dash.dependencies import Input, Output
 
 
 def callback():
     @dash_app.callback(
-        Output(component_id='my-div', component_property='children'),
-        [Input(component_id='my-id', component_property='value')]
+        Output('page-content', 'children'),
+        [
+            dash.dependencies.Input('url', 'pathname'),
+            dash.dependencies.Input('url', 'href'),
+        ],
     )
-    def update_output_div(input_value):
-        return 'You\'ve entered "{}"'.format(input_value)
+    def display_page(pathname, href):
+        from dash_integration.dashboard import simple_dash
+        from dash_integration.dashboard import simple_dash2
+
+        if href:
+            # extract information from url
+            parsed_uri = urllib.parse.urlparse(href)
+            url_param = urllib.parse.parse_qs(parsed_uri.query)
+            dashboard = url_param.get('dashboard', '')[0]
+
+            if dashboard == 'Test1':
+                return simple_dash.get_layout()
+            elif dashboard == 'Test2':
+                return simple_dash2.layout
+            else:
+                return '404'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 frappe
+dash
+dash-daq


### PR DESCRIPTION
Instead of using `DispatcherMiddleware` to embed dash application with frappe application we changing that into passing request from frappe application to flask server then forward that request to dash application.

From doing that we'll able to access frappe variable and function from dash application.

We still use `iframe` to embed dash app into frappe page because frappe page construct function is too complicate.